### PR TITLE
Unit test for StateMachine with log_transitions enabled.

### DIFF
--- a/django_states/log.py
+++ b/django_states/log.py
@@ -100,7 +100,7 @@ def _create_state_log_model(state_model, field_name, machine):
             return ModelBase.__new__(c, class_name, bases, attrs)
 
     get_state_choices = machine.get_state_choices
-
+    
     class _StateTransition(models.Model):
         """
         The log entries for :class:`~django_states.machine.StateTransition`.
@@ -122,9 +122,10 @@ def _create_state_log_model(state_model, field_name, machine):
             verbose_name=_('transition started at')
         )
         on = models.ForeignKey(state_model, related_name=('%s_history' % field_name))
-
+        
         class Meta:
             """Non-field Options"""
+            # noticed ImportError in some cases! https://code.djangoproject.com/ticket/15084 
             verbose_name = _('%s transition') % state_model._meta.verbose_name
 
             # When the state class has been given an app_label, use

--- a/django_states/model_methods.py
+++ b/django_states/model_methods.py
@@ -93,6 +93,14 @@ def get_STATE_info(self, field='state', machine=None):
             return si.description
 
         @property
+        def initial(si_self):
+            """
+            is this the inital state?
+            """
+            si = machine.get_state(getattr(self, field))
+            return bool(si.initial)
+
+        @property
         def in_group(si_self):
             """
             In what groups is this state? It's a dictionary that will return

--- a/django_states/models.py
+++ b/django_states/models.py
@@ -118,7 +118,7 @@ class StateModel(models.Model):
 
         :returns: ``True`` when the current state is the initial state
         """
-        return bool(self.get_state_info().initial)
+        return self.get_state_info().initial
 
     @property
     def possible_transitions(self):


### PR DESCRIPTION
enabled log_transitions lead to ImportErrors when using lazy translated verbose names: https://code.djangoproject.com/ticket/15084
