### PR TITLE
Access to transition_log from StateTransition

### DIFF
--- a/django_states/model_methods.py
+++ b/django_states/model_methods.py
@@ -173,6 +173,7 @@ def get_STATE_info(self, field='state', machine=None):
                 transition_log = _state_log_model.objects.create(
                     on=self, from_state=getattr(self, field), to_state=t.to_state,
                     user=user, serialized_kwargs=serialized_kwargs)
+                t.transition_log = transition_log
 
             # Test transition (access/execution validation)
             try:


### PR DESCRIPTION
I wanted a way to update the `serialized_kwargs` from within my `StateTransition.handler` method, like as follows:

``` python
def handler(self, instance, user, accepted=None, **kwargs):
    instance.accepted = datetime.now() if accepted is None else accepted
    kwargs.update({'accepted': instance.accepted})
    self.transition_log.serialized_kwargs = json.dumps(kwargs, cls=DjangoJSONEncoder)
```

The above code ensures that `accepted` is serialized even if it wasn't supplied in the `make_transition` call.

The patch I've submitted allows for access to the `transition_log` in the `StateTransition` instance. Obviously It's a very simple approach to solving the problem...

Note that my commit message should read:

> Transition log is _now_ available
