### PR TITLE
Remove traceback print and reraise original exc.

### DIFF
--- a/django_states/model_methods.py
+++ b/django_states/model_methods.py
@@ -206,10 +206,7 @@ def get_STATE_info(self, field='state', machine=None):
                 if _state_log_model:
                     transition_log.make_transition('fail')
 
-                # Print original traceback for debugging
-                import traceback
-                traceback.print_exc()
-                raise e
+                raise
             else:
                 if _state_log_model:
                     transition_log.make_transition('complete')


### PR DESCRIPTION
The print was there for debug purpose but was also printed when the
error was correctly handled.
The reraising of the error preserves the original traceback and makes
the print no longer necessary.
