### PR TITLE
Remove verbose_name on abstract State model

### DIFF
--- a/django_states/models.py
+++ b/django_states/models.py
@@ -83,8 +83,6 @@ class StateModel(models.Model):
             description = _('Make dummy state transition')
 
     class Meta:
-        verbose_name = _('state')
-        verbose_name_plural = _('states')
         abstract = True
 
     def __unicode__(self):


### PR DESCRIPTION
A verbose_name on an abstract model has almost no use and can only lead
to confusion. If a subclass does not provide its own verbose_name it
will inherit the verbose_name of the parent instead of the django
generated version.
