### PR TITLE
[Feature] Multi-database support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 ~~~~~~~~~
 CHANGELOG
 ~~~~~~~~~
+1.6.0
+=====
+Release date:
+  2013-11-20
+Notes:
+  * Adds support for Django's multi-database features.
+  * Updates readme
+
 v1.4.3
 ======
 Release date:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ p = Purchase()
 # Will automatically create state object for this purchase, in the
 # initial state.
 p.save()
-p.make_transition('initiate', request.user) # User parameter is optional
+p.make_transition('mark_paid', request.user) # User parameter is optional
 p.state # Will return 'paid'
 p.state_description # Will return 'Purchase paid'
 
@@ -189,7 +189,7 @@ You can get a graph of your states by running the ``graph_states`` management
 command.
 
 ```sh
-python manage.py graph_states myapp.Purchase.state
+python manage.py graph_states2 myapp.Purchase.state
 ```
 
 This requires [graphviz](http://graphviz.org) and python bindings for

--- a/django_states/__init__.py
+++ b/django_states/__init__.py
@@ -7,7 +7,7 @@ State transitions can be logged for objects.
 """
 
 #: The version list
-VERSION = (1, 5, 0)
+VERSION = (1, 6, 0)
 
 #: The actual version number, used by python (and shown in sentry)
 __version__ = '.'.join(map(str, VERSION))

--- a/django_states/models.py
+++ b/django_states/models.py
@@ -3,8 +3,7 @@
 
 # Author: Jonathan Slenders, CityLive
 
-__doc__ = \
-"""
+__doc__ = """
 
 Base models for every State.
 
@@ -181,3 +180,14 @@ class StateModel(models.Model):
     @classmethod
     def get_state_choices(cls):
         return cls.Machine.get_state_choices()
+
+    def get_using_db(self):
+        """
+        Returns which database to use when creating, filter, saving, etc.
+
+        See: https://docs.djangoproject.com/en/dev/topics/db/multi-db/#selecting-a-database-for-save
+
+        If you aren't using multiple databases, this can be left as 'default'.
+
+        """
+        return 'default'


### PR DESCRIPTION
I've added support for multiple databases. We needed this for my work at Wave (https://github.com/waveaccounting) where we have many models that are on different databases (shards).
## Problem

You have models that aren't on the default database.
## Solution

Support multi-database as implemented in Django (specify `using` when saving, filter, creating, etc).
### How to use

In your model, define a `get_using_db()` method. This will return the name of the database to use. The rest is handled internally.
## Assumptions

The only real assumption I made was that your logs will be on the same database as your main model. In my specific application this is true - related data to the main model are on the same database for access reasons.
