### PR TITLE
Replaces simplejson imports with python's json module

### DIFF
--- a/django_states/log.py
+++ b/django_states/log.py
@@ -5,10 +5,11 @@
 Suport for Django 1.5 custom user model.
 """
 
+import json
+
 from django.db import models
 from django.db.models.base import ModelBase
 from django.utils.translation import ugettext_lazy as _
-from django.utils import simplejson as json
 from django.conf import settings
 
 from django_states import conf

--- a/django_states/model_methods.py
+++ b/django_states/model_methods.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Model Methods"""
 
-from django.utils import simplejson as json
+import json
 
 from django_states.exceptions import PermissionDenied, TransitionCannotStart, \
     TransitionException, TransitionNotValidated, UnknownTransition


### PR DESCRIPTION
This PR fixes a warning produced running on Django 1.6.2 but I suspect this should be the same on all 1.6.x.

The warning reads:

```
DeprecationWarning: django.utils.simplejson is deprecated; use json instead.
```
