### PR TITLE
docs: Fix simple typo, succesfully -> successfully

### DIFF
--- a/django_states/models.py
+++ b/django_states/models.py
@@ -163,7 +163,7 @@ class StateModel(six.with_metaclass(StateModelBase, models.Model)):
         :type: :class:`django.contrib.auth.models.User` or ``None``
 
         :returns:``True`` when we expect this transition to be executed
-            succesfully. It will raise an ``Exception`` when this
+            successfully. It will raise an ``Exception`` when this
             transition is impossible or not allowed.
         """
         return self.get_state_info().test_transition(transition, user=user)


### PR DESCRIPTION
There is a small typo in django_states/models.py.

Should read `successfully` rather than `succesfully`.

